### PR TITLE
Update FRUS annotation guide with 1981-88 volume insights

### DIFF
--- a/docs/frus-annotation-style.md
+++ b/docs/frus-annotation-style.md
@@ -1,7 +1,28 @@
-# FRUS Annotation Style (Model Volume frus1989-92v31)
+# FRUS Annotation Style (Model Volumes frus1989-92v31 and frus1981-88v04)
 
-Summary of annotation conventions observed in the reference volume. Use
-this as the textual companion to the in-app quick reference.
+Summary of annotation conventions observed in the two reference volumes
+reviewed so far. Use this as the textual companion to the in-app quick
+reference.
+
+## Document headings
+
+* Reproduce the printed heading verbatim inside `<head>` without
+  normalising case or punctuation. In both volumes the pattern starts
+  with the document genre—“Memorandum,” “Telegram,” “Letter,” “Minutes,”
+  and so forth—followed by a chain of prepositions (“From,” “of,” “to,”
+  “between”) that identify the participants.
+* Identify each principal by name and role. Spell out titles (“Secretary
+  of State Haig”) rather than using abbreviations. Where the print
+  edition uses small caps for names, the TEI preserves this with `<hi
+  rend="smallcaps">` wrapped around the full name or the surname.
+* When a single person holds multiple offices, retain the comma-delimited
+  list exactly as printed (“the Under Secretary of State for Political
+  Affairs and the Director of Central Intelligence”). Multi-sender
+  headings keep the conjunction “and” (not an ampersand).
+* Subordinate qualifiers—such as parenthetical references to annexes or
+  teleconference numbers—remain part of the heading text. Avoid moving
+  them into notes; the head should give the researcher the same quick
+  orientation as the printed book.
 
 ## Source notes
 
@@ -34,6 +55,13 @@ this as the textual companion to the in-app quick reference.
   * `Unclassified.`
 * Frequently cite drafting / approval info in the middle clause:
   `Drafted by ...; approved by ...;`.
+* When the physical description requires additional qualifiers—“Telegram,”
+  “Memorandum of conversation,” “No. 12345”—treat each as a semicolon
+  clause in the order witnessed in the volume. Cable numbers and handling
+  tags appear immediately after the format clause, before classification.
+* Transmission data such as “Sent ...” and “Received ...” stay in the same
+  sentence. In the 1981–1988 volume they trail the classification, joined
+  by semicolons (`Secret; Niact Immediate; Sent ...; Received ...`).
 
 ## Editorial annotations
 
@@ -53,6 +81,11 @@ this as the textual companion to the in-app quick reference.
 * Identify the document with `@subtype="telegram"` on the enclosing
   `<div type="document">`. Heads follow the pattern “Telegram From … to …”
   and preserve the exact capitalization that appears in print.
+* The body heading often includes the sending post and addressee exactly as
+  printed (“Telegram From the Embassy in Islamabad to the Department of
+  State”). Do not expand or contract geographic qualifiers—retain “in,”
+  “to,” and references to bureaus such as “the Mission to the United
+  Nations.”
 * Include a full dateline in the `<opener>`, combining the origin city,
   calendar date, and Zulu time. Encode the clock value with `<time
   when="YYYY-MM-DDThh:mmZ">` so downstream tools can parse the send time.
@@ -73,6 +106,9 @@ this as the textual companion to the in-app quick reference.
   If the telegram carried an “Cleared by …” line beneath the signature,
   encode it as an additional `<p>` so the clearance remains part of the
   document body.
+* When telegrams include a repeat or information addressee list, encode it
+  as printed inside the body—typically as an initial paragraph in small
+  caps—rather than moving it into notes.
 
 ## Cross-reference notes
 


### PR DESCRIPTION
## Summary
- document how FRUS headings are transcribed, based on the 1981–1988 reference volume
- expand the source note guidance with ordering rules for cable metadata and transmission times
- clarify telegram-specific heading language and treatment of repeat addressees

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c26762e8832f8c5bccdbf4995ef4