### PR TITLE
Fix Streamlit dependency issue and initialize OpenAI client from env

### DIFF
--- a/agents/volume_suggester.py
+++ b/agents/volume_suggester.py
@@ -1,0 +1,5 @@
+import os
+
+from openai import OpenAI
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+openai>=1.0.0
+numpy


### PR DESCRIPTION
### Motivation
- Ensure the Streamlit app has required runtime dependencies so it can be installed and deployed. 
- Ensure the OpenAI client is initialized from an environment-provided API key and keep the existing import shape.

### Description
- Add a root-level `requirements.txt` containing `streamlit`, `openai>=1.0.0`, and `numpy`.
- Add `agents/volume_suggester.py` with `from openai import OpenAI` and `client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))` to initialize from the environment.
- Do not change application behavior beyond adding dependencies and environment-based client initialization.
- Note that for Streamlit Community Cloud deployments the `OPENAI_API_KEY` must be set in app secrets/environment variables.

### Testing
- Ran `python -m py_compile agents/volume_suggester.py`, which succeeded. 
- Verified the new files were added to the repository (`requirements.txt` and `agents/volume_suggester.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab49e182f0832fa5276432e4a862e1)